### PR TITLE
places centrale + source ENS

### DIFF
--- a/content/posts/mp2i.md
+++ b/content/posts/mp2i.md
@@ -82,8 +82,9 @@ Lycées avec les plus hauts taux d'admission :
 Il faut savoir que rien n'est encore fixé et que ce sont des engagements de minimum mais voici une petite idée des places aux concours 2023 :
 
 - L'X : [30 places](https://www.ip-paris.fr/actualites/les-5-ecoles-de-linstitut-polytechnique-de-paris-accueilleront-les-eleves-de-la-nouvelle-filiere-mpi)
-- Les ENS : 30 places
+- Les ENS : [30 places](https://www.ens.psl.eu/actualites/des-2023-le-concours-d-entree-aux-ens-ouvrira-aux-etudiants-issus-des-cpge-mp2impi)
 - Concours Mines-ponts : [minimum 75 places](https://www.concoursminesponts.fr/page-8/) (dont 15 pour l'ENSTA, [20 à 30 pour Telecom Paris](https://www.telecom-paris.fr/fr/ingenieur/comment-integrer/admission-post-prepa), une dizaine pour SUPAERO)
+- Concours Centrale : [Minimum 120 places](https://www.centralesupelec.fr/sites/default/files/mpi_centralesupelec_decembre_2021.pdf) (Nombre sous estimé)
 - CCINP : au moins 200 places ([dont 40 pour L'Ensimag](https://ensimag.grenoble-inp.fr/fr/mpi))
 
 ## Les prépas MP2I en France


### PR DESCRIPTION
Je me suis basée sur les effectifs en MPSI à la rentrée 2020 dans les lycées français, donc avec les abandons, les passages en PSI et l'ouverture de la MP2I, il y a "trop d'élèves" comptés donc la proportion est "trop faible", c'est pour ça que c'est sous estimé (mais ça donne un minimum). Et j'ai pris 1000 élèves en MPI.